### PR TITLE
Add dep to imports as well

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     methods,
     scran,
     scater,
+    scDiagnostics,
     ggplot2
 Remotes:
      ccb-hms/scDiagnostics


### PR DESCRIPTION
"You can mark any regular dependency defined in the Depends, Imports, Suggests or Enhances fields as being installed from a remote location by adding the remote location to Remotes in your DESCRIPTION file." xref https://remotes.r-lib.org/articles/dependencies.html

Thus, dependency needs to be both listed as a dependency, and its remote location specified, not just the latter as you did.